### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ I was initially insipired by a control in the Destiny App, so I'd recommend chec
 ## Installation
 
 
-1. MMScrollPresenter can be installed via [Cocoapods](http://cocoapods.org/) by adding `pod 'MMScrollPresenter'` to your podfile, or you can manually include `MMScrollPresenter.h/.m`, `MMScrollPage.h/.m`, `arrow/@2x.png` in your app.
+1. MMScrollPresenter can be installed via [CocoaPods](http://cocoapods.org/) by adding `pod 'MMScrollPresenter'` to your podfile, or you can manually include `MMScrollPresenter.h/.m`, `MMScrollPage.h/.m`, `arrow/@2x.png` in your app.
 2. Add a UIScrollView into your Interface Builder and under the custom class section, subclass your UIScrollView to MMScrollPresenter.
 3. Now add: `@property (nonatomic, weak) IBOutlet MMScrollPresenter *mmScrollPresenter;` to your list of properties and dont forget to link it up in your Interface Builder.
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
